### PR TITLE
feat: use fettle config by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,10 +15,12 @@ repositories {
 dependencies {
     implementation("org.kohsuke:github-api:1.313")
     implementation("org.jetbrains.kotlinx", "kotlinx-cli", "0.3.5")
+    implementation("org.yaml:snakeyaml:2.0")
     // Use the Kotlin test library.
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+
 }
 
 application {

--- a/src/main/kotlin/dev/fidil/fettle/FettleApplication.kt
+++ b/src/main/kotlin/dev/fidil/fettle/FettleApplication.kt
@@ -34,7 +34,7 @@ fun createFettleConfigDirIfNotExists() {
 }
 
 fun checkFettleConfigPermissions() {
-    if (!GitHubConfig.fettleDir.exists()) {
+    if (!GitHubConfig.configFile.exists()) {
         return
     }
     val actualPermission = Files.getPosixFilePermissions(GitHubConfig.configFile.toPath())
@@ -48,7 +48,7 @@ fun getGitHubConfig(): Pair<String, String> {
     var ghUser: String? = null
     var ghToken: String? = null
 
-    if (GitHubConfig.fettleDir.exists()) {
+    if (GitHubConfig.configFile.exists()) {
         val yaml = Yaml()
         val configData = yaml.loadAs(GitHubConfig.configFile.inputStream(), GitHubConfig::class.java)
 
@@ -58,7 +58,7 @@ fun getGitHubConfig(): Pair<String, String> {
             ghToken = githubConfig.token
         }
     }
-    
+
     if (ghUser == null) {
         ghUser = System.getenv("GH_USER")
     }

--- a/src/main/kotlin/dev/fidil/fettle/FettleApplication.kt
+++ b/src/main/kotlin/dev/fidil/fettle/FettleApplication.kt
@@ -4,24 +4,88 @@ package dev.fidil.fettle
 
 import dev.fidil.fettle.command.BranchProtectionCommand
 import dev.fidil.fettle.command.DependabotCommand
+import dev.fidil.fettle.config.GitHubConfig
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
+import org.yaml.snakeyaml.Yaml
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
 import java.util.*
 import kotlin.system.exitProcess
 
 
 fun main(args: Array<String>) {
-    val ghToken = System.getenv("GH_TOKEN")
-    val ghUser = System.getenv("GH_USER")
-    if (ghToken == null || ghUser == null) {
-        println("A valid GitHub user and token are required to be in your environment. Example \nexport GH_TOKEN=sometoken\nexport GH_USER=myuser")
-        exitProcess(1)
-    }
+    createFettleConfigIfNotExists()
+    val (ghUser, ghToken) = getGitHubConfig()
 
     val parser = ArgParser("fettle-cli")
     parser.subcommands(BranchProtectionCommand(ghUser, ghToken), DependabotCommand(ghUser, ghToken))
     parser.parse(args)
 
     println("╭ᥥ╮(´• ᴗ •`˵)╭ᥥ╮")
+}
+fun createFettleConfigIfNotExists() {
+    val fettleDir = File(System.getProperty("user.home"), ".fettle")
+    val configFile = File(fettleDir, "config.yaml")
+    val requiredFilePermission = PosixFilePermissions.fromString("rw-------")
 
+    if (!fettleDir.exists()) {
+        if (fettleDir.mkdir()) {
+        } else {
+            println("Failed to create the fettle config directory.")
+            exitProcess(1)
+        }
+    }
+    if (!configFile.exists()) {
+        try {
+            configFile.createNewFile()
+            Files.setPosixFilePermissions(
+                configFile.toPath(),
+                requiredFilePermission
+            )
+        } catch (ex: Exception) {
+            println("Failed to create the fettle config file")
+            exitProcess(1)
+        }
+    }
+    else {
+        val actualPermission = Files.getPosixFilePermissions(configFile.toPath())
+        if (actualPermission != requiredFilePermission) {
+            println("Fettle config has the wrong permission. Please set it to 600")
+            exitProcess(1)
+        }
+    }
+}
+
+fun getGitHubConfig(): Pair<String, String> {
+    val fettleDir = File(System.getProperty("user.home"), ".fettle")
+    val configFile = File(fettleDir, "config.yaml")
+
+    val yaml = Yaml()
+    val configData = yaml.loadAs(configFile.inputStream(), GitHubConfig::class.java)
+
+    var ghUser: String? = null
+    var ghToken: String? = null
+
+    if (configData != null) {
+        val githubConfig = configData.github
+        ghUser = githubConfig.user
+        ghToken = githubConfig.token
+    }
+
+    if (ghUser == null) {
+        ghUser = System.getenv("GH_USER")
+    }
+
+    if (ghToken == null) {
+        ghToken = System.getenv("GH_TOKEN")
+    }
+
+    if (ghToken == null || ghUser == null) {
+        println("A valid GitHub user and token are required to be in your fettle config or in your environment. Environment Example: \nexport GH_TOKEN=sometoken\nexport GH_USER=myuser")
+        exitProcess(1)
+    }
+
+    return Pair(ghUser, ghToken)
 }

--- a/src/main/kotlin/dev/fidil/fettle/config/GitHubConfig.kt
+++ b/src/main/kotlin/dev/fidil/fettle/config/GitHubConfig.kt
@@ -1,6 +1,14 @@
 package dev.fidil.fettle.config
 
+import java.io.File
+import java.nio.file.attribute.PosixFilePermissions
+
 data class GitHubConfig(var github: GitHub) {
+    companion object {
+        val fettleDir = File(System.getProperty("user.home"), ".fettle")
+        val configFile = File(fettleDir, "config.yaml")
+        val requiredFilePermission = PosixFilePermissions.fromString("rw-------")
+    }
     constructor() : this(GitHub("", ""))
 }
 

--- a/src/main/kotlin/dev/fidil/fettle/config/GitHubConfig.kt
+++ b/src/main/kotlin/dev/fidil/fettle/config/GitHubConfig.kt
@@ -1,0 +1,9 @@
+package dev.fidil.fettle.config
+
+data class GitHubConfig(var github: GitHub) {
+    constructor() : this(GitHub("", ""))
+}
+
+data class GitHub(var user: String?, var token: String?) {
+    constructor() : this(null, null)
+}


### PR DESCRIPTION
- Uses fettle config for github creds.
- Will create fettle config if one doesn't exist
- Checks for 600 permission on fettle config
- Falls back to environment variables if fettle config doesn't contain github creds

Used chatGPT to make @mikeylive
