### PR TITLE
feat: added check for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ Fettle Score: F
 ./fettle staticCodeAnalysis -o fidildev -r fettle
 ```
 
+#### Readme Exists
+
+```shell
+./fettle readme -o fidildev -r fettle
+```
+
+
 ## Star Count
 
 [![Stargazers over time](https://starchart.cc/fidildev/fettle.svg)](https://starchart.cc/fidildev/fettle)

--- a/src/main/kotlin/dev/fidil/fettle/command/ReadmeCommand.kt
+++ b/src/main/kotlin/dev/fidil/fettle/command/ReadmeCommand.kt
@@ -1,0 +1,11 @@
+package dev.fidil.fettle.command
+
+import dev.fidil.fettle.handler.FettleHandler
+
+class ReadmeCommand(override val handler: FettleHandler) :
+    GitHubRepoSubCommand("readme", "Validate Readme exists in the repo") {
+
+    override fun processCommand(): CommandResult {
+        return handler.readme(org, repo, branch)
+    }
+}

--- a/src/main/kotlin/dev/fidil/fettle/handler/FettleHandler.kt
+++ b/src/main/kotlin/dev/fidil/fettle/handler/FettleHandler.kt
@@ -18,4 +18,6 @@ interface FettleHandler {
     fun codeCoverage(org: String, repo: String, branch: String): CommandResult
 
     fun score(org: String, repo: String, branch: String): CommandResult
+
+    fun readme(org: String, repo: String, branch: String): CommandResult
 }


### PR DESCRIPTION
Created a Fettle function that checks for the existence of a readme

Example with a readme
<img width="919" alt="image" src="https://user-images.githubusercontent.com/6320493/235822725-5dd73641-75d9-4284-9f5d-d6635d324c7b.png">

Example without a readme
<img width="905" alt="image" src="https://user-images.githubusercontent.com/6320493/235822920-12940b5f-80df-45ee-9d81-2113d4e838b8.png">

closes #69 
